### PR TITLE
Update info.md to fix link

### DIFF
--- a/info.md
+++ b/info.md
@@ -2,7 +2,7 @@
 
 * [Main Project Page](https://owasp.org/www-project-appsec-pipeline/)
 * [- Pipeline Tools](https://owasp.org/www-project-appsec-pipeline/pipeline-tools.html)
-* [- Pipeline Design Patterns](https://owasp.org/www-project-appsec-pipeline/pipeline-design.patterns.html)
+* [- Pipeline Design Patterns](https://owasp.org/www-project-appsec-pipeline/pipeline-design-patterns.html)
 * [- Pipeline Presentations](https://owasp.org/www-project-appsec-pipeline/presentations.html)
 * [- Pipeline Milestones](https://owasp.org/www-project-appsec-pipeline/milestones.html)
 * [- Pipeline FAQ](https://owasp.org/www-project-appsec-pipeline/faq.html)


### PR DESCRIPTION
link to the design patterns page broken due to a "." instead of a "-", just a small update to fix it. I think this should fix the issue but don't really have a way to test it out. 